### PR TITLE
Fixed fast.ai homepage link

### DIFF
--- a/fastai-video-browser/src/data.js
+++ b/fastai-video-browser/src/data.js
@@ -44,5 +44,5 @@ export const LESSONS_NAMES = [{
 
 export const quickLinks = [
   { title: 'Course Home', href: 'https://course.fast.ai/' },
-  { title: 'fast.ai', href: 'https://fast.ai/' },
+  { title: 'fast.ai', href: 'https://www.fast.ai/' },
 ]


### PR DESCRIPTION
If you navigate to `https://fast.ai` you set an SSL error, while if you go to `http://fast.ai `you get correctly redirected to: `https://www.fast.ai`.
Not sure what causes this issue but this should fix it.