### PR TITLE
Remove link to "Returning to work".

### DIFF
--- a/docs/start_gradient.md
+++ b/docs/start_gradient.md
@@ -80,8 +80,6 @@ Just click stop on the notebook page or notebook list view. This will end the se
 
 NOTE: When using paid instances, you _will_ be charged for the time that your notebook is running. You must stop the notebook to stop incurring charges.
 
-For more details, updating the course and the fastai library see "[Returning to work](https://course.fast.ai/update_gradient.html)".
-
 * * *
 
 ## Additional considerations:


### PR DESCRIPTION
The link "Returning to work" in https://course.fast.ai/start_gradient points to a page that yields a 404 error as described in issue #10. 
In the same issue the resolution is to remove the link.
This removes said link and the surrounding text related to the link.