### PR TITLE
Don't cd to fastbook

### DIFF
--- a/docs/start_gradient.md
+++ b/docs/start_gradient.md
@@ -54,7 +54,6 @@ Once you click on 'Terminal' a new window should open with a terminal. Type:
 
 then
 
-    cd fastbook
     git pull
 
 Now you should close the terminal window.


### PR DESCRIPTION
When you start a terminal in the Paperspace Gradient notebook, the CWD is `/notebook`, which is already a Git repository (with remote `origin` set to `https://github.com/fastai/fastbook.git`). So you can directly `git pull` without changing directory.