### PR TITLE
fix search_images_ddg

### DIFF
--- a/fastbook/__init__.py
+++ b/fastbook/__init__.py
@@ -54,7 +54,7 @@ def search_images_ddg(term, max_images=200):
     "Search for `term` with DuckDuckGo and return a unique urls of about `max_images` images"
     assert max_images<1000
     url = 'https://duckduckgo.com/'
-    res = urlread(url,data={'q':term}).decode()
+    res = urlread(url,data={'q':term})
     searchObj = re.search(r'vqd=([\d-]+)\&', res)
     assert searchObj
     requestUrl = url + 'i.js'


### PR DESCRIPTION
### Problem

I was getting errors running `search_images_ddg` as described [here](https://course.fast.ai/images#DuckDuckGo) (see stacktrace below).

```py
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-10-10909d1f3d49> in <module>
      1 from fastbook import *
----> 2 urls = search_images_ddg('grizzly bear', max_images=100)

/usr/local/lib/python3.7/dist-packages/fastbook/__init__.py in search_images_ddg(term, max_images)
     55     assert max_images<1000
     56     url = 'https://duckduckgo.com/'
---> 57     res = urlread(url,data={'q':term}).decode()
     58     searchObj = re.search(r'vqd=([\d-]+)\&', res)
     59     assert searchObj

AttributeError: 'str' object has no attribute 'decode'
```

It turns out that the `urlread` function in `fastcore` already [seems to `decode` now by default](https://github.com/fastai/fastcore/blob/1731545f272f5cc9f345f63bd0fafcc594a8d106/fastcore/net.py#L115).

### Proposed Fix
This fix simply removes the call to decode the response from urlread, as it is now already decoded.

### Callout re: this solution
In the process of trying to fix the issue, I noticed that the `fastbook` repo has a separate implementation of `search_images_ddg` in the [utils.py file](https://github.com/fastai/fastbook/blob/a8701a6af3f1ebdc5cd98bb5f857968df829e65b/utils.py#L43-L67), which does not have the same double decode issue.  I considered unifying and replacing the implementation here in this course20 repo with the one from the fastbook utils.py, but that would also introduce a change to the parameter names and thus, would require a change to the course website documentation https://course.fast.ai/images#DuckDuckGo.  Because of this, I decided the better approach was to just patch this current implementation.
