### PR TITLE
adjusted for changes in fastcore's urlread

### DIFF
--- a/fastbook/__init__.py
+++ b/fastbook/__init__.py
@@ -54,7 +54,7 @@ def search_images_ddg(term, max_images=200):
     "Search for `term` with DuckDuckGo and return a unique urls of about `max_images` images"
     assert max_images<1000
     url = 'https://duckduckgo.com/'
-    res = urlread(url,data={'q':term}).decode()
+    res = urlread(url,data={'q':term})
     searchObj = re.search(r'vqd=([\d-]+)\&', res)
     assert searchObj
     requestUrl = url + 'i.js'


### PR DESCRIPTION
fastcore's new urlread comes with parameter 'decode=True'. This additional .decode() leads to error.

This has already been discussed in issue #45 but seemingly not solved.

This is a trivial fix and I've tested with a modified version of _search_images_ddg_ locally to make sure it works.