### PR TITLE
Fix mamba install command by including fastai channel

### DIFF
--- a/docs/start_aws.md
+++ b/docs/start_aws.md
@@ -141,7 +141,7 @@ nvidia-smi
 
 Now you're ready to install all needed packages for the fast.ai course:
 
-    mamba install -y fastbook
+    mamba install -y -c fastai fastbook
 
 To download the notebooks, run:
 


### PR DESCRIPTION
# Fix mamba install command by including fastai channel

## Description
I followed the instructions to start using FastAI on AWS, and I found that the command given by the instructions did not work. The command was:
```
mamba install -y fastbook
```

When I tried the command exactly as written, the result was this error from Mamba stating that no such package could be found:
```
Looking for: ['fastbook']

conda-forge/noarch                                   8.2MB @   3.3MB/s  3.0s
conda-forge/linux-64                                23.1MB @   3.9MB/s  7.4s

Pinned packages:
  - python 3.9.*


Encountered problems while solving:
  - nothing provides requested fastbook
```

After some digging, I found that the [official conda install instructions](https://anaconda.org/fastai/fastbook) for fastbook included a `-c` flag to specify which channel to download from. The channel is `fastai`.

Therefore, the new and corrected command in the instructions should be:
```
mamba install -y -c fastai fastbook
```

I've included that change in this PR. Please let me know if anything needs to change.