### PR TITLE
Fix install fail when OS defaults to non utf-8 encodings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
     install_requires = requirements,
     extras_require = { 'dev': dev_requirements },
     python_requires  = '>=' + cfg['min_python'],
-    long_description = open('README.md').read(),
+    long_description = open('README.md', encoding='utf-8').read(),
     long_description_content_type = 'text/markdown',
     zip_safe = False,
     entry_points = { 'console_scripts': cfg.get('console_scripts','').split() },


### PR DESCRIPTION
I'm running into an issue that local `pip install -e` failed on the open. Changing it to open with `utf-8` fixed it for me.